### PR TITLE
Allow expressions for binary sizes

### DIFF
--- a/erlang-squid/src/main/java/org/sonar/erlang/parser/ErlangGrammarImpl.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/parser/ErlangGrammarImpl.java
@@ -589,7 +589,8 @@ public enum ErlangGrammarImpl implements GrammarRuleKey {
       b.sequence(expression,
         b.optional(
           colon,
-          b.firstOf(numericLiteral, atom, identifier, macroLiteral)),
+          b.firstOf(numericLiteral, atom, identifier, macroLiteral,
+            b.sequence(lparenthesis, expression, rparenthesis))),
         b.optional(
           div,
           /*

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserBinaryExpressionTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserBinaryExpressionTest.java
@@ -47,6 +47,7 @@ public class ErlangParserBinaryExpressionTest {
       .matches("<< << (X*2) >> || <<X>> <= method1(), method2() >>")
       .matches("<<Part1:4/big-unsigned-integer-unit:8," +
         "Part2:4/big-unsigned-integer-unit:8," +
-        "Body/binary>>");
+        "Body/binary>>")
+      .matches("<<A:(12 + 4)>>");
   }
 }


### PR DESCRIPTION
Prior to this change it wasn't possible to have an expression when
setting the size of a binary, although it's valid Erlang. An example
would be:

   <<1024:(12 + 4)>>
