### PR TITLE
Record field access can be an identifier

### DIFF
--- a/erlang-squid/src/main/java/org/sonar/erlang/parser/ErlangGrammarImpl.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/parser/ErlangGrammarImpl.java
@@ -537,7 +537,8 @@ public enum ErlangGrammarImpl implements GrammarRuleKey {
       stringConcatenation,
       b.zeroOrMore(
         b.firstOf(
-          b.sequence(numbersign, primaryExpression),
+          // in defines a record might have an identifier to access a field
+          b.sequence(numbersign, primaryExpression, b.optional(".", identifier)),
           b.sequence(macroLiteral, b.optional(".", primaryExpression)))
         )
       ).skipIfOneChild();

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ModuleAttributesTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ModuleAttributesTest.java
@@ -61,7 +61,8 @@ public class ModuleAttributesTest {
       .matches("-define(PARAM_TOKEN_TIMEOUT,                    60*15).")
       .matches("-define (is_uint16 (V), V >= 0, V =< 65535).")
       .matches("-define(TEST(B), ?LOG(??B ++ \" ~p~n\", [B])).")
-      .matches("-define(IN_QUEUE(CState), CState =:= waiting; CState =:= originating; CState =:= ringing).");
+      .matches("-define(IN_QUEUE(CState), CState =:= waiting; CState =:= originating; CState =:= ringing).")
+      .matches("-define(SOME(A), B#c.A).");
   }
 
   @Test


### PR DESCRIPTION
If you use a function within a define, you might access a record field
with and indentifier.
