### PR TITLE
Disable the ErlangLibrarySensor plugin

### DIFF
--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangPlugin.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangPlugin.java
@@ -106,9 +106,10 @@ public class ErlangPlugin extends SonarPlugin {
 
       CoverCoverageSensor.class,
 
-      DialyzerSensor.class,
+      DialyzerSensor.class
 
-      ErlangLibrarySensor.class);
+      //ErlangLibrarySensor.class
+      );
   }
 
 }

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/ErlangPluginTest.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/ErlangPluginTest.java
@@ -35,7 +35,7 @@ public class ErlangPluginTest {
 
   @Test
   public void testGetExtensions() throws Exception {
-    assertThat(plugin.getExtensions().size()).isEqualTo(13);
+    assertThat(plugin.getExtensions().size()).isEqualTo(12);
   }
 
 }


### PR DESCRIPTION
I'm using Erlang 17.5, rebar 3.0.0-alpha-6, and SonarQube 5.1. When I run `sonar-runner`, I get an "Unable to persist" exception (included in full below).

I wrote to Tamás, who suggested that the library sensor wasn't particularly informative anyway and that removing it might be a fine idea. Once I attempted this suggestion, the sonar-erlang plugin begin working for me. In case this is useful to others, here's the small patch to comment-out the library sensor (I can rewrite this PR to actually delete the code if nobody uses it).

Exception when I leave it in:
```
ERROR: Error during Sonar runner execution
org.sonar.runner.impl.RunnerException: Unable to execute Sonar
	at org.sonar.runner.impl.BatchLauncher$1.delegateExecution(BatchLauncher.java:91)
	at org.sonar.runner.impl.BatchLauncher$1.run(BatchLauncher.java:75)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.sonar.runner.impl.BatchLauncher.doExecute(BatchLauncher.java:69)
	at org.sonar.runner.impl.BatchLauncher.execute(BatchLauncher.java:50)
	at org.sonar.runner.api.EmbeddedRunner.doExecute(EmbeddedRunner.java:102)
	at org.sonar.runner.api.Runner.execute(Runner.java:100)
	at org.sonar.runner.Main.executeTask(Main.java:70)
	at org.sonar.runner.Main.execute(Main.java:59)
	at org.sonar.runner.Main.main(Main.java:53)
Caused by: javax.persistence.PersistenceException: Unable to persist : DependencyDto[id=7,fromSnapshotId=1680,fromResourceId=911,fromScope=PRJ,toSnapshotId=<null>,toResourceId=<null>,toScope=PRJ,weight=1,usage=compile,projectSnapshotId=1680,parentDependencyId=<null>]
	at org.sonar.jpa.session.JpaDatabaseSession.internalSave(JpaDatabaseSession.java:136)
	at org.sonar.jpa.session.JpaDatabaseSession.save(JpaDatabaseSession.java:103)
	at org.sonar.batch.index.DependencyPersister.saveInDB(DependencyPersister.java:82)
	at org.sonar.batch.index.DependencyPersister.saveDependency(DependencyPersister.java:57)
	at org.sonar.batch.index.DefaultIndex.addDependency(DefaultIndex.java:288)
	at org.sonar.batch.deprecated.DeprecatedSensorContext.saveDependency(DeprecatedSensorContext.java:219)
	at org.sonar.plugins.erlang.libraries.ErlangLibrarySensor.saveDependency(ErlangLibrarySensor.java:110)
	at org.sonar.plugins.erlang.libraries.ErlangLibrarySensor.analyzeRebarConfigFile(ErlangLibrarySensor.java:84)
	at org.sonar.plugins.erlang.libraries.ErlangLibrarySensor.analyse(ErlangLibrarySensor.java:53)
	at org.sonar.batch.phases.SensorsExecutor.executeSensor(SensorsExecutor.java:59)
	at org.sonar.batch.phases.SensorsExecutor.execute(SensorsExecutor.java:51)
	at org.sonar.batch.phases.DatabaseModePhaseExecutor.execute(DatabaseModePhaseExecutor.java:120)
	at org.sonar.batch.scan.ModuleScanContainer.doAfterStart(ModuleScanContainer.java:264)
	at org.sonar.api.platform.ComponentContainer.startComponents(ComponentContainer.java:92)
	at org.sonar.api.platform.ComponentContainer.execute(ComponentContainer.java:77)
	at org.sonar.batch.scan.ProjectScanContainer.scan(ProjectScanContainer.java:235)
	at org.sonar.batch.scan.ProjectScanContainer.scanRecursively(ProjectScanContainer.java:230)
	at org.sonar.batch.scan.ProjectScanContainer.doAfterStart(ProjectScanContainer.java:220)
	at org.sonar.api.platform.ComponentContainer.startComponents(ComponentContainer.java:92)
	at org.sonar.api.platform.ComponentContainer.execute(ComponentContainer.java:77)
	at org.sonar.batch.scan.ScanTask.scan(ScanTask.java:57)
	at org.sonar.batch.scan.ScanTask.execute(ScanTask.java:45)
	at org.sonar.batch.bootstrap.TaskContainer.doAfterStart(TaskContainer.java:135)
	at org.sonar.api.platform.ComponentContainer.startComponents(ComponentContainer.java:92)
	at org.sonar.api.platform.ComponentContainer.execute(ComponentContainer.java:77)
	at org.sonar.batch.bootstrap.GlobalContainer.executeTask(GlobalContainer.java:158)
	at org.sonar.batch.bootstrapper.Batch.executeTask(Batch.java:95)
	at org.sonar.batch.bootstrapper.Batch.execute(Batch.java:67)
	at org.sonar.runner.batch.IsolatedLauncher.execute(IsolatedLauncher.java:48)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.sonar.runner.impl.BatchLauncher$1.delegateExecution(BatchLauncher.java:87)
	... 9 more
Caused by: javax.persistence.PersistenceException: org.hibernate.PropertyValueException: not-null property references a null or transient value: org.sonar.api.design.DependencyDto.toResourceId
	at org.hibernate.ejb.AbstractEntityManagerImpl.throwPersistenceException(AbstractEntityManagerImpl.java:614)
	at org.hibernate.ejb.AbstractEntityManagerImpl.persist(AbstractEntityManagerImpl.java:226)
	at org.sonar.jpa.session.JpaDatabaseSession.internalSave(JpaDatabaseSession.java:130)
	... 42 more
Caused by: org.hibernate.PropertyValueException: not-null property references a null or transient value: org.sonar.api.design.DependencyDto.toResourceId
	at org.hibernate.engine.Nullability.checkNullability(Nullability.java:95)
	at org.hibernate.event.def.AbstractSaveEventListener.performSaveOrReplicate(AbstractSaveEventListener.java:313)
	at org.hibernate.event.def.AbstractSaveEventListener.performSave(AbstractSaveEventListener.java:204)
	at org.hibernate.event.def.AbstractSaveEventListener.saveWithGeneratedId(AbstractSaveEventListener.java:144)
	at org.hibernate.ejb.event.EJB3PersistEventListener.saveWithGeneratedId(EJB3PersistEventListener.java:49)
	at org.hibernate.event.def.DefaultPersistEventListener.entityIsTransient(DefaultPersistEventListener.java:154)
	at org.hibernate.event.def.DefaultPersistEventListener.onPersist(DefaultPersistEventListener.java:110)
	at org.hibernate.event.def.DefaultPersistEventListener.onPersist(DefaultPersistEventListener.java:61)
	at org.hibernate.impl.SessionImpl.firePersist(SessionImpl.java:646)
	at org.hibernate.impl.SessionImpl.persist(SessionImpl.java:620)
	at org.hibernate.impl.SessionImpl.persist(SessionImpl.java:624)
	at org.hibernate.ejb.AbstractEntityManagerImpl.persist(AbstractEntityManagerImpl.java:220)
	... 43 more
```